### PR TITLE
Add Read event support. Update description of Delivered events

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -8,12 +8,12 @@ const (
 	UnknownAction Action = iota - 1
 	// TextAction means that the event was a text message (May contain attachments).
 	TextAction
-	// DeliveryAction means that the event was advising of a successful delivery to a 
+	// DeliveryAction means that the event was advising of a successful delivery to a
 	// previous recipient.
 	DeliveryAction
-        // ReadAction means that the event was a previous recipient reading their respective
-        // messages.
-        ReadAction
+	// ReadAction means that the event was a previous recipient reading their respective
+	// messages.
+	ReadAction
 	// PostBackAction represents post call back
 	PostBackAction
 )

--- a/actions.go
+++ b/actions.go
@@ -8,9 +8,12 @@ const (
 	UnknownAction Action = iota - 1
 	// TextAction means that the event was a text message (May contain attachments).
 	TextAction
-	// DeliveryAction means that the event was a previous recipient reading their respective
-	// messages.
+	// DeliveryAction means that the event was advising of a successful delivery to a 
+	// previous recipient.
 	DeliveryAction
+        // ReadAction means that the event was a previous recipient reading their respective
+        // messages.
+        ReadAction
 	// PostBackAction represents post call back
 	PostBackAction
 )

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -42,10 +42,15 @@ func main() {
 		r.Text(fmt.Sprintf("Hello, %v!", p.FirstName))
 	})
 
-	// Setup a handler to be triggered when a message is read
+	// Setup a handler to be triggered when a message is delivered
 	client.HandleDelivery(func(d messenger.Delivery, r *messenger.Response) {
-		fmt.Println(d.Watermark().Format(time.UnixDate))
+		fmt.Println("Delivered at:", d.Watermark().Format(time.UnixDate))
 	})
+
+        // Setup a handler to be triggered when a message is read
+        client.HandleDelivery(func(m messenger.Read, r *messenger.Response) {
+                fmt.Println("Read at:", m.Watermark().Format(time.UnixDate))
+        })
 
 	fmt.Println("Serving messenger bot on localhost:8080")
 

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -47,10 +47,10 @@ func main() {
 		fmt.Println("Delivered at:", d.Watermark().Format(time.UnixDate))
 	})
 
-        // Setup a handler to be triggered when a message is read
-        client.HandleDelivery(func(m messenger.Read, r *messenger.Response) {
-                fmt.Println("Read at:", m.Watermark().Format(time.UnixDate))
-        })
+	// Setup a handler to be triggered when a message is read
+	client.HandleDelivery(func(m messenger.Read, r *messenger.Response) {
+		fmt.Println("Read at:", m.Watermark().Format(time.UnixDate))
+	})
 
 	fmt.Println("Serving messenger bot on localhost:8080")
 

--- a/message.go
+++ b/message.go
@@ -35,11 +35,11 @@ type Delivery struct {
 // Delivery represents a the event fired when a message is read by the
 // recipient.
 type Read struct {
-        // RawWatermark is the timestamp before which all messages have been read
+	// RawWatermark is the timestamp before which all messages have been read
 	// by the user
-        RawWatermark int64 `json:"watermark"`
-        // Seq is the sequence the message was sent in.
-        Seq int `json:"seq"`
+	RawWatermark int64 `json:"watermark"`
+	// Seq is the sequence the message was sent in.
+	Seq int `json:"seq"`
 }
 
 // PostBack represents postback callback
@@ -61,5 +61,5 @@ func (d Delivery) Watermark() time.Time {
 
 // Watermark is the RawWatermark timestamp rendered as a time.Time.
 func (r Read) Watermark() time.Time {
-        return time.Unix(r.RawWatermark, 0)
+	return time.Unix(r.RawWatermark, 0)
 }

--- a/message.go
+++ b/message.go
@@ -21,15 +21,25 @@ type Message struct {
 	Attachments []Attachment `json:"attachments"`
 }
 
-// Delivery represents a the event fired when a recipient reads one of Messengers sent
-// messages.
+// Delivery represents a the event fired when Facebook delivers a message to the
+// recipient.
 type Delivery struct {
 	// Mids are the IDs of the messages which were read.
 	Mids []string `json:"mids"`
-	// RawWatermark is the timestamp contained in the message of when the read was.
+	// RawWatermark is the timestamp of when the delivery was.
 	RawWatermark int64 `json:"watermark"`
 	// Seq is the sequence the message was sent in.
 	Seq int `json:"seq"`
+}
+
+// Delivery represents a the event fired when a message is read by the
+// recipient.
+type Read struct {
+        // RawWatermark is the timestamp before which all messages have been read
+	// by the user
+        RawWatermark int64 `json:"watermark"`
+        // Seq is the sequence the message was sent in.
+        Seq int `json:"seq"`
 }
 
 // PostBack represents postback callback
@@ -47,4 +57,9 @@ type PostBack struct {
 // Watermark is the RawWatermark timestamp rendered as a time.Time.
 func (d Delivery) Watermark() time.Time {
 	return time.Unix(d.RawWatermark, 0)
+}
+
+// Watermark is the RawWatermark timestamp rendered as a time.Time.
+func (r Read) Watermark() time.Time {
+        return time.Unix(r.RawWatermark, 0)
 }

--- a/messenger.go
+++ b/messenger.go
@@ -44,7 +44,7 @@ type Messenger struct {
 	mux              *http.ServeMux
 	messageHandlers  []MessageHandler
 	deliveryHandlers []DeliveryHandler
-        readHandlers []ReadHandler
+	readHandlers     []ReadHandler
 	postBackHandlers []PostBackHandler
 	token            string
 	verifyHandler    func(http.ResponseWriter, *http.Request)
@@ -82,7 +82,7 @@ func (m *Messenger) HandleDelivery(f DeliveryHandler) {
 // HandleRead adds a new DeliveryHandler to the Messenger which will be triggered
 // when a previously sent message is read by the recipient.
 func (m *Messenger) HandleRead(f ReadHandler) {
-        m.readHandlers = append(m.readHandlers, f)
+	m.readHandlers = append(m.readHandlers, f)
 }
 
 // HandlePostBack adds a new PostBackHandler to the Messenger
@@ -169,10 +169,10 @@ func (m *Messenger) dispatch(r Receive) {
 				for _, f := range m.deliveryHandlers {
 					f(*info.Delivery, resp)
 				}
-                        case ReadAction:
-                                for _, f := range m.readHandlers {
-                                        f(*info.Read, resp)
-                                }
+			case ReadAction:
+				for _, f := range m.readHandlers {
+					f(*info.Read, resp)
+				}
 			case PostBackAction:
 				for _, f := range m.postBackHandlers {
 					message := *info.PostBack
@@ -192,8 +192,8 @@ func (m *Messenger) classify(info MessageInfo, e Entry) Action {
 		return TextAction
 	} else if info.Delivery != nil {
 		return DeliveryAction
-        } else if info.Read != nil {
-                return ReadAction
+	} else if info.Read != nil {
+		return ReadAction
 	} else if info.PostBack != nil {
 		return PostBackAction
 	}

--- a/profile.go
+++ b/profile.go
@@ -5,4 +5,7 @@ type Profile struct {
 	FirstName     string `json:"first_name"`
 	LastName      string `json:"last_name"`
 	ProfilePicURL string `json:"profile_pic"`
+	Locale	      string `json:"locale"`
+	Timezone      int    `json:"timezone"`
+	Gender	      string `json:"gender"`
 }

--- a/profile.go
+++ b/profile.go
@@ -5,7 +5,7 @@ type Profile struct {
 	FirstName     string `json:"first_name"`
 	LastName      string `json:"last_name"`
 	ProfilePicURL string `json:"profile_pic"`
-	Locale	      string `json:"locale"`
+	Locale        string `json:"locale"`
 	Timezone      int    `json:"timezone"`
-	Gender	      string `json:"gender"`
+	Gender        string `json:"gender"`
 }

--- a/receiving.go
+++ b/receiving.go
@@ -35,6 +35,8 @@ type MessageInfo struct {
 	Delivery *Delivery `json:"delivery"`
 
 	PostBack *PostBack `json:"postback"`
+
+	Read *Read `json:"read"`
 }
 
 // Sender is who the message was sent from.


### PR DESCRIPTION
Since the 1st July 2016 API update there is a distinction between delivered (sent to a user) and read (read by the user) events.
I've added support for the read event. Echo event support might be next if I get excited, it's a pretty easy add given the structure of the code.
