### PR TITLE
Fixin timestamp handling as Facebook sends back milliseconds timestamps

### DIFF
--- a/message.go
+++ b/message.go
@@ -60,10 +60,10 @@ type PostBack struct {
 
 // Watermark is the RawWatermark timestamp rendered as a time.Time.
 func (d Delivery) Watermark() time.Time {
-	return time.Unix(d.RawWatermark, 0)
+	return time.Unix(d.RawWatermark/int64(time.Microsecond), 0)
 }
 
 // Watermark is the RawWatermark timestamp rendered as a time.Time.
 func (r Read) Watermark() time.Time {
-	return time.Unix(r.RawWatermark, 0)
+	return time.Unix(r.RawWatermark/int64(time.Microsecond), 0)
 }

--- a/messenger.go
+++ b/messenger.go
@@ -232,7 +232,7 @@ func (m *Messenger) dispatch(r Receive) {
 					message := *info.Message
 					message.Sender = info.Sender
 					message.Recipient = info.Recipient
-					message.Time = time.Unix(info.Timestamp, 0)
+					message.Time = time.Unix(info.Timestamp/int64(time.Microsecond), 0)
 					f(message, resp)
 				}
 			case DeliveryAction:
@@ -248,7 +248,7 @@ func (m *Messenger) dispatch(r Receive) {
 					message := *info.PostBack
 					message.Sender = info.Sender
 					message.Recipient = info.Recipient
-					message.Time = time.Unix(info.Timestamp, 0)
+					message.Time = time.Unix(info.Timestamp/int64(time.Microsecond), 0)
 					f(message, resp)
 				}
 			}


### PR DESCRIPTION
I don't know if that changed recently but I had some weird behavior with dates. Here is a fix. 
Looks like Facebook sends back milliseconds timestamps. 
Feel to merge this or replace the `int64(time.Microsecond)` into a const value of `1000`.

And thanks for the great work you provided :D

Also, thanks to `jmoiron` on IRC for the help :)
