### PR TITLE
Support sent attachment by url.

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -305,6 +305,16 @@ func (m *Messenger) SendWithReplies(to Recipient, message string, replies []Quic
 	return response.TextWithReplies(message, replies)
 }
 
+// Attachment sends an image, sound, video or a regular file to a given recipient.
+func (m *Messenger) Attachment(to Recipient, dataType AttachmentType, url string) error {
+	response := &Response{
+		token: m.token,
+		to:    to,
+	}
+
+	return response.Attachment(dataType, url)
+}
+
 // classify determines what type of message a webhook event is.
 func (m *Messenger) classify(info MessageInfo, e Entry) Action {
 	if info.Message != nil {


### PR DESCRIPTION
Example:

``` go
client.Attachment(To, "image", "https://cdn3.iconfinder.com/data/icons/picons-social/57/16-apple-256.png")
client.Attachment(To, "audio", "https://archive.org/download/testmp3testfile/mpthreetest.mp3")
client.Attachment(To, "video", "http://www.sample-videos.com/video/mp4/480/big_buck_bunny_480p_5mb.mp4")
client.Attachment(To, "file", "http://open.qiniudn.com/where-can-you-use-golang.pdf")
```

<img width="416" alt="screen shot 2016-10-08 at 12 52 19 pm" src="https://cloud.githubusercontent.com/assets/21979/19210461/2c8eb0dc-8d56-11e6-9049-66df527a35d3.png">

Signed-off-by: Bo-Yi Wu appleboy.tw@gmail.com
