### PR TITLE
CallToActionItem missing fields

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -20,8 +20,10 @@ type CallToActionsSetting struct {
 
 // CallToActionsItem contains Get Started button or item of Persist Menu
 type CallToActionsItem struct {
-	Type    string `json:"type,omitempty"`
-	Title   string `json:"title,omitempty"`
-	Payload string `json:"payload,omitempty"`
-	URL     string `json:"url,omitempty"`
+	Type               string `json:"type,omitempty"`
+	Title              string `json:"title,omitempty"`
+	Payload            string `json:"payload,omitempty"`
+	URL                string `json:"url,omitempty"`
+	WebviewHeightRatio string `json:"webview_height_ratio,omitempty"`
+	MessengerExtension bool   `json:"messenger_extensions,omitempty"`
 }

--- a/settings.go
+++ b/settings.go
@@ -1,5 +1,22 @@
 package messenger
 
+// Defines the different sizes available when setting up a CallToActionsItem
+// of type "web_url". These values can be used in the "WebviewHeightRatio"
+// field.
+const (
+	// WebviewCompact opens the page in a web view that takes half the screen
+	// and covers only part of the conversation.
+	WebviewCompact = "compact"
+
+	// WebviewTall opens the page in a web view that covers about 75% of the
+	// conversation.
+	WebviewTall = "tall"
+
+	// WebviewFull opens the page in a web view that completely covers the
+	// conversation, and has a "back" button instead of a "close" one.
+	WebviewFull = "full"
+)
+
 // GreetingSetting is the setting for greeting message
 type GreetingSetting struct {
 	SettingType string       `json:"setting_type"`


### PR DESCRIPTION
Hey there 🎉 

Just noticed there were two missing fields in the `CallToActionItem` struct. 

See [this page](https://developers.facebook.com/docs/messenger-platform/thread-settings/persistent-menu) and especially the `menu_item` section for more details. 

`WebviewHeightRatio` was tested and works. Possible values (as described in the messenger docs) are : `compact`, `tall` or `full`

Thanks again for your great work, and I hope that will help ! 🎆 