### PR TITLE
add json omitempty on button Title field

### DIFF
--- a/response.go
+++ b/response.go
@@ -347,7 +347,7 @@ type StructuredMessageElement struct {
 type StructuredMessageButton struct {
 	Type    string `json:"type"`
 	URL     string `json:"url,omitempty"`
-	Title   string `json:"title"`
+	Title   string `json:"title,omitempty"`
 	Payload string `json:"payload,omitempty"`
 }
 


### PR DESCRIPTION
Share Button only allows the Type field to be presented in the serialized data. Otherwise, you got facebook error:

"Facebook error : (#100) Param [elements][0][buttons][0][title] must be a non-empty UTF-8 encoded string"