### PR TITLE
Reuse Post Code

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -313,6 +313,15 @@ func (m *Messenger) Send(to Recipient, message string) error {
 	return m.SendWithReplies(to, message, nil)
 }
 
+//SendGeneralMessage will send the GenericTemplate message
+func (m *Messenger) SendGeneralMessage(to Recipient, elements *[]StructuredMessageElement) error {
+	r := &Response{
+		token: m.token,
+		to:    to,
+	}
+	return r.GenericTemplate(elements)
+}
+
 // SendWithReplies sends a textual message to a user, but gives them the option of numerous quick response options.
 func (m *Messenger) SendWithReplies(to Recipient, message string, replies []QuickReply) error {
 	response := &Response{

--- a/messenger.go
+++ b/messenger.go
@@ -330,7 +330,7 @@ func (m *Messenger) Send(to Recipient, message string) error {
 	return m.SendWithReplies(to, message, nil)
 }
 
-//SendGeneralMessage will send the GenericTemplate message
+// SendGeneralMessage will send the GenericTemplate message
 func (m *Messenger) SendGeneralMessage(to Recipient, elements *[]StructuredMessageElement) error {
 	r := &Response{
 		token: m.token,

--- a/response.go
+++ b/response.go
@@ -76,26 +76,7 @@ func (r *Response) TextWithReplies(message string, replies []QuickReply) error {
 			QuickReplies: replies,
 		},
 	}
-
-	data, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", SendMessageURL, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.URL.RawQuery = "access_token=" + r.token
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
-	defer resp.Body.Close()
-
-	return err
+	return r.PostToMessenger(&m)
 }
 
 // AttachmentWithReplies sends a attachment message with some replies
@@ -107,26 +88,7 @@ func (r *Response) AttachmentWithReplies(attachment *StructuredMessageAttachment
 			QuickReplies: replies,
 		},
 	}
-
-	data, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", SendMessageURL, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.URL.RawQuery = "access_token=" + r.token
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
-	defer resp.Body.Close()
-
-	return err
+	return r.PostToMessenger(&m)
 }
 
 // Image sends an image.
@@ -153,26 +115,7 @@ func (r *Response) Attachment(dataType AttachmentType, url string) error {
 			},
 		},
 	}
-
-	data, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", SendMessageURL, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.URL.RawQuery = "access_token=" + r.token
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
-	defer resp.Body.Close()
-
-	return err
+	return r.PostToMessenger(&m)
 }
 
 // AttachmentData sends an image, sound, video or a regular file to a chat via an io.Reader.
@@ -230,28 +173,7 @@ func (r *Response) ButtonTemplate(text string, buttons *[]StructuredMessageButto
 		},
 	}
 
-	data, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", SendMessageURL, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.URL.RawQuery = "access_token=" + r.token
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return checkFacebookError(resp.Body)
+	return r.PostToMessenger(&m)
 }
 
 // GenericTemplate is a message which allows for structural elements to be sent
@@ -269,29 +191,7 @@ func (r *Response) GenericTemplate(elements *[]StructuredMessageElement) error {
 			},
 		},
 	}
-
-	data, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", SendMessageURL, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.URL.RawQuery = "access_token=" + r.token
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return checkFacebookError(resp.Body)
+	return r.PostToMessenger(&m)
 }
 
 // SenderAction sends a info about sender action
@@ -300,7 +200,11 @@ func (r *Response) SenderAction(action string) error {
 		Recipient:    r.to,
 		SenderAction: action,
 	}
+	return r.PostToMessenger(&m)
+}
 
+// PostToMessenger posts the message to messenger, return the error if there's any
+func (r *Response) PostToMessenger(m interface{}) error {
 	data, err := json.Marshal(m)
 	if err != nil {
 		return err
@@ -314,14 +218,14 @@ func (r *Response) SenderAction(action string) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.URL.RawQuery = "access_token=" + r.token
 
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-
+	if resp.StatusCode == 200 {
+		return nil
+	}
 	return checkFacebookError(resp.Body)
 }
 

--- a/response.go
+++ b/response.go
@@ -331,7 +331,7 @@ type SendMessage struct {
 	Message   MessageData `json:"message"`
 }
 
-// MessageData is a text Or attachment message with optional replies to be sent.
+// MessageData is a message consisting of text or an attachment, with an additional selection of optional quick replies.
 type MessageData struct {
 	Text         string                       `json:"text,omitempty"`
 	Attachment   *StructuredMessageAttachment `json:"attachment,omitempty"`

--- a/response.go
+++ b/response.go
@@ -72,6 +72,38 @@ func (r *Response) TextWithReplies(message string, replies []QuickReply) error {
 		Recipient: r.to,
 		Message: MessageData{
 			Text:         message,
+			Attachment:   nil,
+			QuickReplies: replies,
+		},
+	}
+
+	data, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", SendMessageURL, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.URL.RawQuery = "access_token=" + r.token
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	defer resp.Body.Close()
+
+	return err
+}
+
+// AttachmentWithReplies sends a attachment message with some replies
+func (r *Response) AttachmentWithReplies(attachment *StructuredMessageAttachment, replies []QuickReply) error {
+	m := SendMessage{
+		Recipient: r.to,
+		Message: MessageData{
+			Attachment:   attachment,
 			QuickReplies: replies,
 		},
 	}
@@ -299,10 +331,11 @@ type SendMessage struct {
 	Message   MessageData `json:"message"`
 }
 
-// MessageData is a text message with optional replies to be sent.
+// MessageData is a text Or attachment message with optional replies to be sent.
 type MessageData struct {
-	Text         string       `json:"text,omitempty"`
-	QuickReplies []QuickReply `json:"quick_replies,omitempty"`
+	Text         string                       `json:"text,omitempty"`
+	Attachment   *StructuredMessageAttachment `json:"attachment,omitempty"`
+	QuickReplies []QuickReply                 `json:"quick_replies,omitempty"`
 }
 
 // SendStructuredMessage is a structured message template.

--- a/response.go
+++ b/response.go
@@ -76,7 +76,7 @@ func (r *Response) TextWithReplies(message string, replies []QuickReply) error {
 			QuickReplies: replies,
 		},
 	}
-	return r.PostToMessenger(&m)
+	return r.DispatchMessage(&m)
 }
 
 // AttachmentWithReplies sends a attachment message with some replies
@@ -88,7 +88,7 @@ func (r *Response) AttachmentWithReplies(attachment *StructuredMessageAttachment
 			QuickReplies: replies,
 		},
 	}
-	return r.PostToMessenger(&m)
+	return r.DispatchMessage(&m)
 }
 
 // Image sends an image.
@@ -115,7 +115,7 @@ func (r *Response) Attachment(dataType AttachmentType, url string) error {
 			},
 		},
 	}
-	return r.PostToMessenger(&m)
+	return r.DispatchMessage(&m)
 }
 
 // AttachmentData sends an image, sound, video or a regular file to a chat via an io.Reader.
@@ -173,7 +173,7 @@ func (r *Response) ButtonTemplate(text string, buttons *[]StructuredMessageButto
 		},
 	}
 
-	return r.PostToMessenger(&m)
+	return r.DispatchMessage(&m)
 }
 
 // GenericTemplate is a message which allows for structural elements to be sent
@@ -191,7 +191,7 @@ func (r *Response) GenericTemplate(elements *[]StructuredMessageElement) error {
 			},
 		},
 	}
-	return r.PostToMessenger(&m)
+	return r.DispatchMessage(&m)
 }
 
 // SenderAction sends a info about sender action
@@ -200,11 +200,11 @@ func (r *Response) SenderAction(action string) error {
 		Recipient:    r.to,
 		SenderAction: action,
 	}
-	return r.PostToMessenger(&m)
+	return r.DispatchMessage(&m)
 }
 
-// PostToMessenger posts the message to messenger, return the error if there's any
-func (r *Response) PostToMessenger(m interface{}) error {
+// DispatchMessage posts the message to messenger, return the error if there's any
+func (r *Response) DispatchMessage(m interface{}) error {
 	data, err := json.Marshal(m)
 	if err != nil {
 		return err

--- a/response.go
+++ b/response.go
@@ -347,7 +347,7 @@ type StructuredMessageElement struct {
 type StructuredMessageButton struct {
 	Type    string `json:"type"`
 	URL     string `json:"url,omitempty"`
-	Title   string `json:"title"`
+	Title   string `json:"title,omitempty"`
 	Payload string `json:"payload,omitempty"`
 }
 


### PR DESCRIPTION
- Created PostToMessenger method to be reused in all send methods
- Only checks facebook response body if statusCode is not 200
- Enforce all sends are checking the facebook error in PostToMessenger method

Might consider do same thing cross all the post actions?