### PR TITLE
fixed error return value

### DIFF
--- a/response.go
+++ b/response.go
@@ -50,9 +50,10 @@ func checkFacebookError(r io.Reader) error {
 	err = json.NewDecoder(r).Decode(&qr)
 	if qr.Error != nil {
 		err = fmt.Errorf("Facebook error : %s", qr.Error.Message)
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // Response is used for responding to events with messages.
@@ -151,9 +152,7 @@ func (r *Response) AttachmentData(dataType AttachmentType, filename string, file
 		return err
 	}
 
-	var res bytes.Buffer
-	res.ReadFrom(resp.Body)
-	return nil
+	return checkFacebookError(resp.Body)
 }
 
 // ButtonTemplate sends a message with the main contents being button elements


### PR DESCRIPTION
Not sure about original intent behind original code on lines 154-155, but it definitely droped error messages returned by facebok. I've changed the code to use already existing facebookError function, and changed this function to return nill in case of no error.

I've found this during investigation of issues with sending an image as an attachment (it's not working for me) so it's possible that more PR/issue reports are coming