### PR TITLE
added messaging_type for FB send API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a Go library for making bots to be used on Facebook messenger. It is bui
 `paked/messenger` is a pretty stable library however, changes will be made which might break backwards compatibility. For the convenience of its users, these are documented here.
 
 
+- 06/2/18: Added messaging_type field for message send API request as it is required by FB
 - [23/1/17](https://github.com/paked/messenger/commit/1145fe35249f8ce14d3c0a52544e4a4babdc15a4): Updating timezone type to `float64` in profile struct
 - [12/9/16](https://github.com/paked/messenger/commit/47f193fc858e2d710c061e88b12dbd804a399e57): Removing unused parameter `text string` from function `(r *Response) GenericTemplate`.
 - [20/5/16](https://github.com/paked/messenger/commit/1dc4bcc67dec50e2f58436ffbc7d61ca9da5b943): Leaving the `WebhookURL` field blank in `Options` will yield a URL of "/" instead of a panic.

--- a/messenger.go
+++ b/messenger.go
@@ -384,37 +384,37 @@ func (m *Messenger) Response(to int64) *Response {
 }
 
 // Send will send a textual message to a user. This user must have previously initiated a conversation with the bot.
-func (m *Messenger) Send(to Recipient, message string) error {
-	return m.SendWithReplies(to, message, nil)
+func (m *Messenger) Send(to Recipient, message string, messagingType MessagingType, tags ...string) error {
+	return m.SendWithReplies(to, message, nil, messagingType, tags...)
 }
 
 // SendGeneralMessage will send the GenericTemplate message
-func (m *Messenger) SendGeneralMessage(to Recipient, elements *[]StructuredMessageElement) error {
+func (m *Messenger) SendGeneralMessage(to Recipient, elements *[]StructuredMessageElement, messagingType MessagingType, tags ...string) error {
 	r := &Response{
 		token: m.token,
 		to:    to,
 	}
-	return r.GenericTemplate(elements)
+	return r.GenericTemplate(elements, messagingType, tags...)
 }
 
 // SendWithReplies sends a textual message to a user, but gives them the option of numerous quick response options.
-func (m *Messenger) SendWithReplies(to Recipient, message string, replies []QuickReply) error {
+func (m *Messenger) SendWithReplies(to Recipient, message string, replies []QuickReply, messagingType MessagingType, tags ...string) error {
 	response := &Response{
 		token: m.token,
 		to:    to,
 	}
 
-	return response.TextWithReplies(message, replies)
+	return response.TextWithReplies(message, replies, messagingType, tags...)
 }
 
 // Attachment sends an image, sound, video or a regular file to a given recipient.
-func (m *Messenger) Attachment(to Recipient, dataType AttachmentType, url string) error {
+func (m *Messenger) Attachment(to Recipient, dataType AttachmentType, url string, messagingType MessagingType, tags ...string) error {
 	response := &Response{
 		token: m.token,
 		to:    to,
 	}
 
-	return response.Attachment(dataType, url)
+	return response.Attachment(dataType, url, messagingType, tags...)
 }
 
 // classify determines what type of message a webhook event is.


### PR DESCRIPTION
I added messaging_type field for requesting FB send API, it will be required soon to be able to send any messages. Please see [FB doc](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types ) for more info