### PR TITLE
WIP: NLP, CTX, more control over handle and custom http (per request needs)

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/paked/messenger"
+	"context"
+
+	"github.com/dfischer/messenger"
 )
 
 var (
@@ -40,7 +42,7 @@ func main() {
 	})
 
 	// Setup a handler to be triggered when a message is received
-	client.HandleMessage(func(m messenger.Message, r *messenger.Response) {
+	messenger.Handlers.HandleMessage(func(ctx context.Context, m messenger.Message, r *messenger.Response) {
 		fmt.Printf("%v (Sent, %v)\n", m.Text, m.Time.Format(time.UnixDate))
 
 		p, err := client.ProfileByID(m.Sender.ID)
@@ -52,12 +54,12 @@ func main() {
 	})
 
 	// Setup a handler to be triggered when a message is delivered
-	client.HandleDelivery(func(d messenger.Delivery, r *messenger.Response) {
+	messenger.Handlers.HandleDelivery(func(ctx context.Context, d messenger.Delivery, r *messenger.Response) {
 		fmt.Println("Delivered at:", d.Watermark().Format(time.UnixDate))
 	})
 
 	// Setup a handler to be triggered when a message is read
-	client.HandleRead(func(m messenger.Read, r *messenger.Response) {
+	messenger.Handlers.HandleRead(func(ctx context.Context, m messenger.Read, r *messenger.Response) {
 		fmt.Println("Read at:", m.Watermark().Format(time.UnixDate))
 	})
 

--- a/examples/linked-account/main.go
+++ b/examples/linked-account/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -11,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/paked/messenger"
+	"github.com/dfischer/messenger" // just for the PR so build passes
 )
 
 const (
@@ -51,7 +52,7 @@ func main() {
 	})
 
 	// Handle incoming messages
-	client.HandleMessage(func(m messenger.Message, r *messenger.Response) {
+	messenger.Handlers.HandleMessage(func(ctx context.Context, m messenger.Message, r *messenger.Response) {
 		log.Printf("%v (Sent, %v)\n", m.Text, m.Time.Format(time.UnixDate))
 
 		p, err := client.ProfileByID(m.Sender.ID)
@@ -76,7 +77,7 @@ func main() {
 	})
 
 	// Send a feedback to the user after an update of account linking status
-	client.HandleAccountLinking(func(m messenger.AccountLinking, r *messenger.Response) {
+	messenger.Handlers.HandleAccountLinking(func(ctx context.Context, m messenger.AccountLinking, r *messenger.Response) {
 		var text string
 		switch m.Status {
 		case "linked":

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,79 @@
+package messenger
+
+import (
+	"context"
+)
+
+type handlers struct {
+	messageHandlers        []MessageHandler
+	deliveryHandlers       []DeliveryHandler
+	readHandlers           []ReadHandler
+	postBackHandlers       []PostBackHandler
+	optInHandlers          []OptInHandler
+	referralHandlers       []ReferralHandler
+	accountLinkingHandlers []AccountLinkingHandler
+}
+
+// MessageHandler is a handler used for responding to a message containing text.
+type MessageHandler func(context.Context, Message, *Response)
+
+// DeliveryHandler is a handler used for responding to a delivery receipt.
+type DeliveryHandler func(context.Context, Delivery, *Response)
+
+// ReadHandler is a handler used for responding to a read receipt.
+type ReadHandler func(context.Context, Read, *Response)
+
+// PostBackHandler is a handler used postback callbacks.
+type PostBackHandler func(context.Context, PostBack, *Response)
+
+// OptInHandler is a handler used to handle opt-ins.
+type OptInHandler func(context.Context, OptIn, *Response)
+
+// ReferralHandler is a handler used postback callbacks.
+type ReferralHandler func(context.Context, ReferralMessage, *Response)
+
+// AccountLinkingHandler is a handler used to react to an account
+// being linked or unlinked.
+type AccountLinkingHandler func(context.Context, AccountLinking, *Response)
+
+// Handlers contain a registry of handlers matched off intent
+var Handlers = handlers{}
+
+// HandleMessage adds a new MessageHandler to the Messenger which will be triggered
+// when a message is received by the client.
+func (h *handlers) HandleMessage(f MessageHandler) {
+	h.messageHandlers = append(h.messageHandlers, f)
+}
+
+// HandleDelivery adds a new DeliveryHandler to the Messenger which will be triggered
+// when a previously sent message is delivered to the recipient.
+func (h *handlers) HandleDelivery(f DeliveryHandler) {
+	h.deliveryHandlers = append(h.deliveryHandlers, f)
+}
+
+// HandleOptIn adds a new OptInHandler to the Messenger which will be triggered
+// once a user opts in to communicate with the bot.
+func (h *handlers) HandleOptIn(f OptInHandler) {
+	h.optInHandlers = append(h.optInHandlers, f)
+}
+
+// HandleRead adds a new DeliveryHandler to the Messenger which will be triggered
+// when a previously sent message is read by the recipient.
+func (h *handlers) HandleRead(f ReadHandler) {
+	h.readHandlers = append(h.readHandlers, f)
+}
+
+// HandlePostBack adds a new PostBackHandler to the Messenger
+func (h *handlers) HandlePostBack(f PostBackHandler) {
+	h.postBackHandlers = append(h.postBackHandlers, f)
+}
+
+// HandleReferral adds a new ReferralHandler to the Messenger
+func (h *handlers) HandleReferral(f ReferralHandler) {
+	h.referralHandlers = append(h.referralHandlers, f)
+}
+
+// HandleAccountLinking adds a new AccountLinkingHandler to the Messenger
+func (h *handlers) HandleAccountLinking(f AccountLinkingHandler) {
+	h.accountLinkingHandlers = append(h.accountLinkingHandlers, f)
+}

--- a/message.go
+++ b/message.go
@@ -23,6 +23,39 @@ type Message struct {
 	Attachments []Attachment `json:"attachments"`
 	// Selected quick reply
 	QuickReply *QuickReply `json:"quick_reply,omitempty"`
+	// Entities for NLP
+	// https://developers.facebook.com/docs/messenger-platform/built-in-nlp/
+	Nlp map[string]Entity `json:"nlp"`
+}
+
+// Entity blah blah
+type Entity struct {
+	Email []Email `json:"email"`
+	URL   []URL   `json:"url"`
+}
+
+// URL Entity
+type URL struct {
+	Domain string `json:"domain"`
+	Value  string `json:"value"`
+	Confidence
+}
+
+// URLValue deeper entity semantics
+type URLValue struct {
+	Domain string `json:"domain"`
+	Value  string `json:"value"`
+}
+
+// Email entity
+type Email struct {
+	Value string `json:"value"`
+	Confidence
+}
+
+// Confidence is how close to 1 the model thinks it is accurate on match
+type Confidence struct {
+	Confidence float64 `json:"confidence"`
 }
 
 // Delivery represents a the event fired when Facebook delivers a message to the
@@ -81,4 +114,9 @@ func (d Delivery) Watermark() time.Time {
 // Watermark is the RawWatermark timestamp rendered as a time.Time.
 func (r Read) Watermark() time.Time {
 	return time.Unix(r.RawWatermark/int64(time.Microsecond), 0)
+}
+
+// Entities returns NLP entities matched from `Entity` struct
+func (m Message) Entities() Entity {
+	return m.Nlp["entities"]
 }

--- a/message.go
+++ b/message.go
@@ -66,6 +66,8 @@ type PostBack struct {
 	Referral Referral `json:"referral"`
 }
 
+// AccountLinking for linking accounts
+// https://developers.facebook.com/docs/messenger-platform/identity/account-linking/
 type AccountLinking struct {
 	// Sender is who the message was sent from.
 	Sender Sender `json:"-"`

--- a/message.go
+++ b/message.go
@@ -1,6 +1,9 @@
 package messenger
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Message represents a Facebook messenge message.
 type Message struct {
@@ -25,37 +28,7 @@ type Message struct {
 	QuickReply *QuickReply `json:"quick_reply,omitempty"`
 	// Entities for NLP
 	// https://developers.facebook.com/docs/messenger-platform/built-in-nlp/
-	Nlp map[string]Entity `json:"nlp"`
-}
-
-// Entity blah blah
-type Entity struct {
-	Email []Email `json:"email"`
-	URL   []URL   `json:"url"`
-}
-
-// URL Entity
-type URL struct {
-	Domain string `json:"domain"`
-	Value  string `json:"value"`
-	Confidence
-}
-
-// URLValue deeper entity semantics
-type URLValue struct {
-	Domain string `json:"domain"`
-	Value  string `json:"value"`
-}
-
-// Email entity
-type Email struct {
-	Value string `json:"value"`
-	Confidence
-}
-
-// Confidence is how close to 1 the model thinks it is accurate on match
-type Confidence struct {
-	Confidence float64 `json:"confidence"`
+	NLP json.RawMessage `json:"nlp"`
 }
 
 // Delivery represents a the event fired when Facebook delivers a message to the
@@ -116,7 +89,8 @@ func (r Read) Watermark() time.Time {
 	return time.Unix(r.RawWatermark/int64(time.Microsecond), 0)
 }
 
-// Entities returns NLP entities matched from `Entity` struct
-func (m Message) Entities() Entity {
-	return m.Nlp["entities"]
+// GetNLP simply unmarshals the NLP entities to the given struct and returns
+// an error if it's not possible
+func (m *Message) GetNLP(i interface{}) error {
+	return json.Unmarshal(m.NLP, &i)
 }

--- a/messenger.go
+++ b/messenger.go
@@ -17,7 +17,7 @@ const (
 	// Used in the form: https://graph.facebook.com/v2.6/<USER_ID>?fields=<PROFILE_FIELDS>&access_token=<PAGE_ACCESS_TOKEN>
 	ProfileURL = "https://graph.facebook.com/v2.6/"
 	// ProfileFields is a list of JSON field names which will be populated by the profile query.
-	ProfileFields = "first_name,last_name,profile_pic,locale,timezone,gender"
+	ProfileFields = "id,name,profile_pic"
 	// SendSettingsURL is API endpoint for saving settings.
 	SendSettingsURL = "https://graph.facebook.com/v2.6/me/thread_settings"
 )

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -1,6 +1,7 @@
 package messenger
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -95,7 +96,7 @@ func TestMessenger_Dispatch(t *testing.T) {
 		m := &Messenger{}
 		h := &handlersCalls{}
 
-		handler := func(msg Message, r *Response) {
+		handler := func(ctx context.Context, msg Message, r *Response) {
 			h.message++
 			assert.NotNil(t, r)
 			assert.EqualValues(t, 111, msg.Sender.ID)
@@ -113,16 +114,18 @@ func TestMessenger_Dispatch(t *testing.T) {
 			},
 		}
 
-		// First handler
-		m.HandleMessage(handler)
+		ctx := context.Background()
 
-		m.dispatch(newReceive(messages))
+		// First handler
+		Handlers.HandleMessage(handler)
+
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{message: 1})
 
 		// Another handler
-		m.HandleMessage(handler)
+		Handlers.HandleMessage(handler)
 
-		m.dispatch(newReceive(messages))
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{message: 3})
 	})
 
@@ -130,7 +133,7 @@ func TestMessenger_Dispatch(t *testing.T) {
 		m := &Messenger{}
 		h := &handlersCalls{}
 
-		handler := func(_ Delivery, r *Response) {
+		handler := func(ctx context.Context, _ Delivery, r *Response) {
 			h.delivery++
 			assert.NotNil(t, r)
 		}
@@ -145,16 +148,18 @@ func TestMessenger_Dispatch(t *testing.T) {
 			},
 		}
 
-		// First handler
-		m.HandleDelivery(handler)
+		ctx := context.Background()
 
-		m.dispatch(newReceive(messages))
+		// First handler
+		Handlers.HandleDelivery(handler)
+
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{delivery: 1})
 
 		// Another handler
-		m.HandleDelivery(handler)
+		Handlers.HandleDelivery(handler)
 
-		m.dispatch(newReceive(messages))
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{delivery: 3})
 	})
 
@@ -162,7 +167,7 @@ func TestMessenger_Dispatch(t *testing.T) {
 		m := &Messenger{}
 		h := &handlersCalls{}
 
-		handler := func(_ Read, r *Response) {
+		handler := func(ctx context.Context, _ Read, r *Response) {
 			h.read++
 			assert.NotNil(t, r)
 		}
@@ -177,16 +182,18 @@ func TestMessenger_Dispatch(t *testing.T) {
 			},
 		}
 
-		// First handler
-		m.HandleRead(handler)
+		ctx := context.Background()
 
-		m.dispatch(newReceive(messages))
+		// First handler
+		Handlers.HandleRead(handler)
+
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{read: 1})
 
 		// Another handler
-		m.HandleRead(handler)
+		Handlers.HandleRead(handler)
 
-		m.dispatch(newReceive(messages))
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{read: 3})
 	})
 
@@ -194,7 +201,7 @@ func TestMessenger_Dispatch(t *testing.T) {
 		m := &Messenger{}
 		h := &handlersCalls{}
 
-		handler := func(msg PostBack, r *Response) {
+		handler := func(ctx context.Context, msg PostBack, r *Response) {
 			h.postback++
 			assert.NotNil(t, r)
 			assert.EqualValues(t, 111, msg.Sender.ID)
@@ -212,16 +219,18 @@ func TestMessenger_Dispatch(t *testing.T) {
 			},
 		}
 
-		// First handler
-		m.HandlePostBack(handler)
+		ctx := context.Background()
 
-		m.dispatch(newReceive(messages))
+		// First handler
+		Handlers.HandlePostBack(handler)
+
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{postback: 1})
 
 		// Another handler
-		m.HandlePostBack(handler)
+		Handlers.HandlePostBack(handler)
 
-		m.dispatch(newReceive(messages))
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{postback: 3})
 	})
 
@@ -229,7 +238,7 @@ func TestMessenger_Dispatch(t *testing.T) {
 		m := &Messenger{}
 		h := &handlersCalls{}
 
-		handler := func(msg OptIn, r *Response) {
+		handler := func(ctx context.Context, msg OptIn, r *Response) {
 			h.optin++
 			assert.NotNil(t, r)
 			assert.EqualValues(t, 111, msg.Sender.ID)
@@ -247,16 +256,18 @@ func TestMessenger_Dispatch(t *testing.T) {
 			},
 		}
 
-		// First handler
-		m.HandleOptIn(handler)
+		ctx := context.Background()
 
-		m.dispatch(newReceive(messages))
+		// First handler
+		Handlers.HandleOptIn(handler)
+
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{optin: 1})
 
 		// Another handler
-		m.HandleOptIn(handler)
+		Handlers.HandleOptIn(handler)
 
-		m.dispatch(newReceive(messages))
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{optin: 3})
 	})
 
@@ -264,7 +275,7 @@ func TestMessenger_Dispatch(t *testing.T) {
 		m := &Messenger{}
 		h := &handlersCalls{}
 
-		handler := func(msg ReferralMessage, r *Response) {
+		handler := func(ctx context.Context, msg ReferralMessage, r *Response) {
 			h.referral++
 			assert.NotNil(t, r)
 			assert.EqualValues(t, 111, msg.Sender.ID)
@@ -282,16 +293,18 @@ func TestMessenger_Dispatch(t *testing.T) {
 			},
 		}
 
-		// First handler
-		m.HandleReferral(handler)
+		ctx := context.Background()
 
-		m.dispatch(newReceive(messages))
+		// First handler
+		Handlers.HandleReferral(handler)
+
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{referral: 1})
 
 		// Another handler
-		m.HandleReferral(handler)
+		Handlers.HandleReferral(handler)
 
-		m.dispatch(newReceive(messages))
+		m.dispatch(ctx, newReceive(messages))
 		assertHandlersCalls(t, h, handlersCalls{referral: 3})
 	})
 }

--- a/profile.go
+++ b/profile.go
@@ -2,7 +2,12 @@ package messenger
 
 // Profile is the public information of a Facebook user
 type Profile struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	ProfilePicURL string `json:"profile_pic"`
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	ProfilePicURL string  `json:"profile_pic"`
+	FirstName     string  `json:"first_name"`
+	LastName      string  `json:"last_name"`
+	Locale        string  `json:"locale"`
+	Timezone      float64 `json:"timezone"`
+	Gender        string  `json:"gender"`
 }

--- a/profile.go
+++ b/profile.go
@@ -2,10 +2,7 @@ package messenger
 
 // Profile is the public information of a Facebook user
 type Profile struct {
-	FirstName     string  `json:"first_name"`
-	LastName      string  `json:"last_name"`
-	ProfilePicURL string  `json:"profile_pic"`
-	Locale        string  `json:"locale"`
-	Timezone      float64 `json:"timezone"`
-	Gender        string  `json:"gender"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	ProfilePicURL string `json:"profile_pic"`
 }

--- a/response.go
+++ b/response.go
@@ -71,8 +71,9 @@ func checkFacebookError(r io.Reader) error {
 
 // Response is used for responding to events with messages.
 type Response struct {
-	token string
-	to    Recipient
+	client *http.Client
+	token  string
+	to     Recipient
 }
 
 // Text sends a textual message.
@@ -207,8 +208,7 @@ func (r *Response) AttachmentData(dataType AttachmentType, filename string, file
 
 	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (r *Response) DispatchMessage(m interface{}) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.URL.RawQuery = "access_token=" + r.token
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Using Google App Engine I had to make modifications to this lib to load it per request. Additionally I wanted to access the Facebook Messenger Wit.ai Integration NLP attributes.

Changes:

1. Made `handle` public so creating a middleware layer is easier.
2. Moved Handler logic/registry to a package global and it's own file instead of being built on Messenger struct. Without this change then handler initialization would be per request which doesn't make much sense.
3. Removed non-standard API items from messenger `ProfileFields` (this should probably be a config object, maybe a TODO for this PR).

Todo:

- [ ] Review examples and update as needed
- [ ] ProfileFields as config object?

------

Example of how I am using it:

```go
func main() {
	// Setup server
	s := newServer()

	// Setup messenger handlers
	messenger.Handlers.HandleMessage(s.messageHandler)

	// Setup router
	http.HandleFunc("/webhook/messenger", s.addEnv(s.messengerHandler))

	// Starts server to receive requests
	appengine.Main()
}

func (s *server) messengerHandler(w http.ResponseWriter, r *http.Request) {
	ctx := r.Context()
	http := ctxHTTP(ctx)

	m := messenger.New(messenger.Options{
		// AppEngine requires urlfetch. Set it in 3rd party lib
		Client:      http,
		Verify:      s.config.messenger.Verify,
		AppSecret:   s.config.messenger.AppSecret,
		VerifyToken: s.config.messenger.VerifyToken,
		Token:       s.config.messenger.Token,
	})

	// Pass incoming messages off to the messenger lib handler
	m.Handle(w, r)
}
```