### PR TITLE
Expose error_subcode property for errors

### DIFF
--- a/response.go
+++ b/response.go
@@ -68,10 +68,11 @@ type QueryResponse struct {
 
 // QueryError is representing an error sent back by Facebook
 type QueryError struct {
-	Message   string `json:"message"`
-	Type      string `json:"type"`
-	Code      int    `json:"code"`
-	FBTraceID string `json:"fbtrace_id"`
+	Message      string `json:"message"`
+	Type         string `json:"type"`
+	Code         int    `json:"code"`
+	ErrorSubcode int    `json:"error_subcode"`
+	FBTraceID    string `json:"fbtrace_id"`
 }
 
 // QueryError implements error


### PR DESCRIPTION
Hi,

Adding a field for `error_subcode`. Named it `ErrorSubcode` to follow FB naming even though error prefix seemed redundant.

More info on this in FB docs: https://developers.facebook.com/docs/messenger-platform/reference/send-api/error-codes