### PR TITLE
Allow to pass custom http.Client

### DIFF
--- a/response.go
+++ b/response.go
@@ -96,8 +96,9 @@ func checkFacebookError(r io.Reader) error {
 
 // Response is used for responding to events with messages.
 type Response struct {
-	token string
-	to    Recipient
+	client *http.Client
+	token  string
+	to     Recipient
 }
 
 // SetToken is for using DispatchMessage from outside.
@@ -348,7 +349,11 @@ func (r *Response) DispatchMessage(m interface{}) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.URL.RawQuery = "access_token=" + r.token
 
-	resp, err := http.DefaultClient.Do(req)
+	client := r.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -381,7 +386,11 @@ func (r *Response) PassThreadToInbox() error {
 	req.Header.Set("Content-Type", "application/json")
 	req.URL.RawQuery = "access_token=" + r.token
 
-	resp, err := http.DefaultClient.Do(req)
+	client := r.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While it was possible to customize http.Client by changing http.DefaultClient, it's not a great solution as it is a global state.

The change was a bit tricky because of requests happening on `Response` object and the possibility of it being initialized manually.